### PR TITLE
Update iPXE.erb

### DIFF
--- a/iPXE.erb
+++ b/iPXE.erb
@@ -9,5 +9,5 @@ oses:
 %>
 
 kernel -n mboot.c32 <%= @host.operatingsystem.medium_uri(@host) %>mboot.c32
-imgargs mboot.c32 -c <%= @host.operatingsystem.medium_uri(@host) %>boot.cfg text ks=<%=foreman_url("provision")%>; ignoreHeadless="True"
+imgargs mboot.c32 -c <%= @host.operatingsystem.medium_uri(@host) %>boot.cfg text ks=<%=foreman_url("provision")%> ignoreHeadless="True"
 boot mboot.c32


### PR DESCRIPTION
template not able to be found due to bad unattended/provision url

removed ; from end of url.
